### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BINList
 [![Build Status](https://travis-ci.org/thii/BINList.svg)](https://travis-ci.org/thii/BINList)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/BINList.svg)](https://img.shields.io/cocoapods/v/BINList.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/BINList.svg)](https://img.shields.io/cocoapods/v/BINList.svg)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 BIN lookup library in Swift.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
